### PR TITLE
show elite toggle button

### DIFF
--- a/src/components/Accordions/TechAddordions.tsx
+++ b/src/components/Accordions/TechAddordions.tsx
@@ -35,7 +35,7 @@ function getTechObjects(techNamesToFind: string[], allTechs: Technology[] | null
 }
 
 function TechAccordions(props: TechAccordionsProps) {
-  // console.log(`TechAccordions: : ${props.unique_techs}`);
+  console.log(`TechAccordions: : ${props.unique_techs}`);
   const allTechs = useContext(TechContext);
   const techNames: string[] = props.unique_techs ? props.unique_techs.split(";") : [];
   const techObjects = getTechObjects(techNames, allTechs);

--- a/src/components/Accordions/TechAddordions.tsx
+++ b/src/components/Accordions/TechAddordions.tsx
@@ -35,7 +35,7 @@ function getTechObjects(techNamesToFind: string[], allTechs: Technology[] | null
 }
 
 function TechAccordions(props: TechAccordionsProps) {
-  console.log(`TechAccordions: : ${props.unique_techs}`);
+  // console.log(`TechAccordions: : ${props.unique_techs}`);
   const allTechs = useContext(TechContext);
   const techNames: string[] = props.unique_techs ? props.unique_techs.split(";") : [];
   const techObjects = getTechObjects(techNames, allTechs);

--- a/src/components/Accordions/UnitAccordions.tsx
+++ b/src/components/Accordions/UnitAccordions.tsx
@@ -12,7 +12,7 @@ import {
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { SettingsContext, UnitContext } from "../../contexts";
-import type { Unit } from "../../types";
+import type { Settings, Unit } from "../../types";
 import { MEDIUM_TAN_COLOR, DARK_TAN_COLOR } from "../../constants";
 import { getCostObject, getCreatedInFileName, getRequiresAgeFileName } from "../../util";
 import { BonusChipList, ChipList, CostDisplay, StatDisplay } from "../Stats";
@@ -22,11 +22,14 @@ type UnitAccordionsProps = {
   iconSize: number;
 };
 
-function getUnitObjects(unitNamesToFind: string[], allUnits: Unit[] | null) {
+function getUnitObjects(unitNamesToFind: string[], allUnits: Unit[] | null, settings: Settings) {
   // console.log("getUnitObjects: " + unitNamesToFind);
   if (!allUnits) return;
   let unitObjects: Unit[] = [];
   unitNamesToFind.forEach((unitName) => {
+    if (!settings.showEliteUnits && unitName.startsWith("Elite")) {
+      return;
+    }
     const result = allUnits.find(({ name }) => name === unitName);
 
     if (result) {
@@ -37,11 +40,11 @@ function getUnitObjects(unitNamesToFind: string[], allUnits: Unit[] | null) {
 }
 
 function UnitAccordions(props: UnitAccordionsProps) {
-  console.log(`UnitAccordions: : ${props.unique_units}`);
+  // console.log(`UnitAccordions: : ${props.unique_units}`);
   const allUnits = useContext(UnitContext);
   const settings = useContext(SettingsContext);
   const unitNames: string[] = props.unique_units ? props.unique_units.split(";") : [];
-  const unitObjects = getUnitObjects(unitNames, allUnits);
+  const unitObjects = getUnitObjects(unitNames, allUnits, settings);
 
   return (
     <div>
@@ -73,7 +76,7 @@ function UnitAccordions(props: UnitAccordionsProps) {
                   <Grid container>
                     <Grid item xs={12}>
                       <Typography variant="body1" fontWeight={600}>
-                        {unit.name} {String(settings?.showEliteUnits)}
+                        {unit.name}
                       </Typography>
                     </Grid>
                     <Grid item xs={12}>

--- a/src/components/Accordions/UnitAccordions.tsx
+++ b/src/components/Accordions/UnitAccordions.tsx
@@ -11,7 +11,7 @@ import {
   Typography,
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import { UnitContext } from "../../contexts";
+import { SettingsContext, UnitContext } from "../../contexts";
 import type { Unit } from "../../types";
 import { MEDIUM_TAN_COLOR, DARK_TAN_COLOR } from "../../constants";
 import { getCostObject, getCreatedInFileName, getRequiresAgeFileName } from "../../util";
@@ -37,8 +37,9 @@ function getUnitObjects(unitNamesToFind: string[], allUnits: Unit[] | null) {
 }
 
 function UnitAccordions(props: UnitAccordionsProps) {
-  // console.log(`UnitAccordions: : ${props.unique_units}`);
+  console.log(`UnitAccordions: : ${props.unique_units}`);
   const allUnits = useContext(UnitContext);
+  const settings = useContext(SettingsContext);
   const unitNames: string[] = props.unique_units ? props.unique_units.split(";") : [];
   const unitObjects = getUnitObjects(unitNames, allUnits);
 
@@ -72,7 +73,7 @@ function UnitAccordions(props: UnitAccordionsProps) {
                   <Grid container>
                     <Grid item xs={12}>
                       <Typography variant="body1" fontWeight={600}>
-                        {unit.name}
+                        {unit.name} {String(settings?.showEliteUnits)}
                       </Typography>
                     </Grid>
                     <Grid item xs={12}>

--- a/src/components/ComparePanels/CivCompare.tsx
+++ b/src/components/ComparePanels/CivCompare.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useCallback, useContext, useMemo, useState } from "react";
-import { Box, Grid } from "@mui/material";
+import { Box, Checkbox, FormControlLabel, Grid } from "@mui/material";
 import type { Civilization } from "../../types";
 import CivCompareDetails from "./CivCompareDetails";
 import { AutoCompleteSelect } from "../Micro";
@@ -40,6 +40,12 @@ export function CivCompare() {
   //   [civs]
   // );
 
+  // const [checked, setChecked] = useState<boolean>(false);
+  // const handleChange = (e: React.ChangeEvent) => {
+  //   console.log("checkbox changed");
+  //   setChecked(!checked);
+  // };
+
   const dropdownOptions = useMemo(() => {
     let dropdownOptions: string[] = [];
     civs?.forEach((civ) => {
@@ -50,6 +56,7 @@ export function CivCompare() {
 
   return (
     <Box sx={{ width: "100%" }}>
+      {/* <Checkbox checked={checked} onChange={handleChange} inputProps={{ "aria-label": "controlled" }} /> */}
       <Grid container spacing={3}>
         <Grid item xs={6}>
           <AutoCompleteSelect options={dropdownOptions} selectCiv={selectCivOne} />

--- a/src/components/ComparePanels/CivCompare.tsx
+++ b/src/components/ComparePanels/CivCompare.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { useCallback, useContext, useMemo, useState } from "react";
-import { Box, Checkbox, FormControlLabel, Grid } from "@mui/material";
+import { useContext, useMemo, useState } from "react";
+import { Box, Grid } from "@mui/material";
 import type { Civilization } from "../../types";
 import CivCompareDetails from "./CivCompareDetails";
 import { AutoCompleteSelect } from "../Micro";
@@ -40,12 +40,6 @@ export function CivCompare() {
   //   [civs]
   // );
 
-  // const [checked, setChecked] = useState<boolean>(false);
-  // const handleChange = (e: React.ChangeEvent) => {
-  //   console.log("checkbox changed");
-  //   setChecked(!checked);
-  // };
-
   const dropdownOptions = useMemo(() => {
     let dropdownOptions: string[] = [];
     civs?.forEach((civ) => {
@@ -56,7 +50,6 @@ export function CivCompare() {
 
   return (
     <Box sx={{ width: "100%" }}>
-      {/* <Checkbox checked={checked} onChange={handleChange} inputProps={{ "aria-label": "controlled" }} /> */}
       <Grid container spacing={3}>
         <Grid item xs={6}>
           <AutoCompleteSelect options={dropdownOptions} selectCiv={selectCivOne} />

--- a/src/components/ComparePanels/CivCompareDetails.tsx
+++ b/src/components/ComparePanels/CivCompareDetails.tsx
@@ -17,6 +17,7 @@ const MARGIN_BETWEEN_DIVIDERS: number = 10;
 const DIVIDER_FONT_WEIGHT: number = 800;
 
 export function CivCompareDetails(props: CivCompareDetailsProps) {
+  console.log("CivCompareDetails");
   return (
     <Card
       sx={{

--- a/src/components/ComparePanels/CivCompareDetails.tsx
+++ b/src/components/ComparePanels/CivCompareDetails.tsx
@@ -17,7 +17,7 @@ const MARGIN_BETWEEN_DIVIDERS: number = 10;
 const DIVIDER_FONT_WEIGHT: number = 800;
 
 export function CivCompareDetails(props: CivCompareDetailsProps) {
-  console.log("CivCompareDetails");
+  // console.log("CivCompareDetails");
   return (
     <Card
       sx={{

--- a/src/components/DashBoard.tsx
+++ b/src/components/DashBoard.tsx
@@ -21,7 +21,7 @@ import {
 } from "@mui/icons-material";
 import { Settings, type Building, type Civilization, type Technology, type Unit } from "../types";
 import { CivComparePage, CivDataPage, TechDataPage, BuildingDataPage, UnitDataPage } from "../pages";
-import { BuildingContext, CivContext, SettingsContext, TechContext, UnitContext } from "../contexts";
+import { BuildingContext, CivContext, DEFAULT_SETTINGS, SettingsContext, TechContext, UnitContext } from "../contexts";
 import { DARK_TAN_COLOR } from "../constants";
 import { AppBar, Drawer, DrawerToolsSection, DrawerDataTablesSection, DrawerLinksSection } from "./Layout";
 import { Copyright } from "./Micro";
@@ -32,24 +32,20 @@ let techData: Technology[] = require("./../data/techs.json");
 let civData: Civilization[] = require("./../data/civs.json");
 let buildingData: Building[] = require("./../data/buildings.json");
 
-const DEFAULT_SETTINGS: Settings = {
-  showEliteUnits: false,
-};
-
 function DashboardContent() {
-  const [open, setOpen] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
   const [units] = useState(unitData);
   const [civs] = useState(civData);
   const [techs] = useState(techData);
   const [buildings] = useState(buildingData);
   const pathName = useLocation().pathname;
-  const [settings, setSettings] = useState(DEFAULT_SETTINGS);
+  const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
 
   const toggleDrawer = () => {
-    setOpen(!open);
+    setDrawerOpen(!drawerOpen);
   };
 
-  const handleChange = () => {
+  const toggleShowElites = () => {
     setSettings({ showEliteUnits: !settings.showEliteUnits });
   };
 
@@ -62,7 +58,7 @@ function DashboardContent() {
               <Box sx={{ display: "flex" }}>
                 <CssBaseline />
 
-                <AppBar position="absolute" open={open}>
+                <AppBar position="absolute" open={drawerOpen}>
                   <Toolbar
                     sx={{
                       pr: "24px", // keep right padding when drawer closed
@@ -75,7 +71,7 @@ function DashboardContent() {
                       onClick={toggleDrawer}
                       sx={{
                         marginRight: "36px",
-                        ...(open && { display: "none" }),
+                        ...(drawerOpen && { display: "none" }),
                       }}
                     >
                       <MenuIcon sx={{ color: DARK_TAN_COLOR }} />
@@ -88,11 +84,15 @@ function DashboardContent() {
                         control={
                           <Checkbox
                             checked={settings.showEliteUnits}
-                            onChange={handleChange}
+                            onChange={toggleShowElites}
                             inputProps={{ "aria-label": "controlled" }}
                           />
                         }
-                        label="Show Elite Units"
+                        label={
+                          <Typography sx={{ color: "black", marginRight: 2, userSelect: "none" }} variant="body1">
+                            Show Elite Units
+                          </Typography>
+                        }
                       />
                     ) : null}
 
@@ -104,7 +104,7 @@ function DashboardContent() {
                   </Toolbar>
                 </AppBar>
 
-                <Drawer variant="permanent" open={open}>
+                <Drawer variant="permanent" open={drawerOpen}>
                   <Toolbar
                     sx={{
                       display: "flex",

--- a/src/components/DashBoard.tsx
+++ b/src/components/DashBoard.tsx
@@ -1,15 +1,27 @@
 import * as React from "react";
 import { useState } from "react";
 import { Routes, Route, useLocation } from "react-router-dom";
-import { Badge, Box, Container, CssBaseline, Divider, List, IconButton, Toolbar, Typography } from "@mui/material";
+import {
+  Badge,
+  Box,
+  Checkbox,
+  Container,
+  CssBaseline,
+  Divider,
+  FormControlLabel,
+  List,
+  IconButton,
+  Toolbar,
+  Typography,
+} from "@mui/material";
 import {
   ChevronLeft as ChevronLeftIcon,
   Menu as MenuIcon,
   Notifications as NotificationsIcon,
 } from "@mui/icons-material";
-import type { Building, Civilization, Technology, Unit } from "../types";
+import { Settings, type Building, type Civilization, type Technology, type Unit } from "../types";
 import { CivComparePage, CivDataPage, TechDataPage, BuildingDataPage, UnitDataPage } from "../pages";
-import { BuildingContext, CivContext, TechContext, UnitContext } from "../contexts";
+import { BuildingContext, CivContext, SettingsContext, TechContext, UnitContext } from "../contexts";
 import { DARK_TAN_COLOR } from "../constants";
 import { AppBar, Drawer, DrawerToolsSection, DrawerDataTablesSection, DrawerLinksSection } from "./Layout";
 import { Copyright } from "./Micro";
@@ -20,6 +32,10 @@ let techData: Technology[] = require("./../data/techs.json");
 let civData: Civilization[] = require("./../data/civs.json");
 let buildingData: Building[] = require("./../data/buildings.json");
 
+const DEFAULT_SETTINGS: Settings = {
+  showEliteUnits: false,
+};
+
 function DashboardContent() {
   const [open, setOpen] = useState(false);
   const [units] = useState(unitData);
@@ -27,97 +43,117 @@ function DashboardContent() {
   const [techs] = useState(techData);
   const [buildings] = useState(buildingData);
   const pathName = useLocation().pathname;
+  const [settings, setSettings] = useState(DEFAULT_SETTINGS);
 
   const toggleDrawer = () => {
     setOpen(!open);
   };
 
-  return (
-    <BuildingContext.Provider value={buildings}>
-      <TechContext.Provider value={techs}>
-        <CivContext.Provider value={civs}>
-          <UnitContext.Provider value={units}>
-            <Box sx={{ display: "flex" }}>
-              <CssBaseline />
+  const handleChange = () => {
+    setSettings({ showEliteUnits: !settings.showEliteUnits });
+  };
 
-              <AppBar position="absolute" open={open}>
-                <Toolbar
-                  sx={{
-                    pr: "24px", // keep right padding when drawer closed
-                  }}
-                >
-                  <IconButton
-                    edge="start"
-                    color="inherit"
-                    aria-label="open drawer"
-                    onClick={toggleDrawer}
+  return (
+    <SettingsContext.Provider value={settings}>
+      <BuildingContext.Provider value={buildings}>
+        <TechContext.Provider value={techs}>
+          <CivContext.Provider value={civs}>
+            <UnitContext.Provider value={units}>
+              <Box sx={{ display: "flex" }}>
+                <CssBaseline />
+
+                <AppBar position="absolute" open={open}>
+                  <Toolbar
                     sx={{
-                      marginRight: "36px",
-                      ...(open && { display: "none" }),
+                      pr: "24px", // keep right padding when drawer closed
                     }}
                   >
-                    <MenuIcon sx={{ color: DARK_TAN_COLOR }} />
-                  </IconButton>
-                  <Typography component="h1" variant="h6" color="black" noWrap sx={{ flexGrow: 1 }}>
-                    AgeOfInfo {pathName === "/" ? " > Compare Civilizations" : null}
-                  </Typography>
-                  <IconButton color="inherit">
-                    <Badge badgeContent={0} color="secondary">
-                      <NotificationsIcon />
-                    </Badge>
-                  </IconButton>
-                </Toolbar>
-              </AppBar>
+                    <IconButton
+                      edge="start"
+                      color="inherit"
+                      aria-label="open drawer"
+                      onClick={toggleDrawer}
+                      sx={{
+                        marginRight: "36px",
+                        ...(open && { display: "none" }),
+                      }}
+                    >
+                      <MenuIcon sx={{ color: DARK_TAN_COLOR }} />
+                    </IconButton>
+                    <Typography component="h1" variant="h6" color="black" noWrap sx={{ flexGrow: 1 }}>
+                      AgeOfInfo {pathName === "/" ? " > Compare Civilizations" : null}
+                    </Typography>
+                    {pathName === "/" ? (
+                      <FormControlLabel
+                        control={
+                          <Checkbox
+                            checked={settings.showEliteUnits}
+                            onChange={handleChange}
+                            inputProps={{ "aria-label": "controlled" }}
+                          />
+                        }
+                        label="Show Elite Units"
+                      />
+                    ) : null}
 
-              <Drawer variant="permanent" open={open}>
-                <Toolbar
+                    <IconButton color="inherit">
+                      <Badge badgeContent={0} color="secondary">
+                        <NotificationsIcon />
+                      </Badge>
+                    </IconButton>
+                  </Toolbar>
+                </AppBar>
+
+                <Drawer variant="permanent" open={open}>
+                  <Toolbar
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "flex-end",
+                      px: [1],
+                    }}
+                  >
+                    <IconButton onClick={toggleDrawer}>
+                      <ChevronLeftIcon />
+                    </IconButton>
+                  </Toolbar>
+                  <Divider />
+                  <List component="nav">
+                    {DrawerToolsSection}
+                    <Divider sx={{ my: 1 }} />
+                    {DrawerDataTablesSection}
+                    <Divider sx={{ my: 1 }} />
+                    {DrawerLinksSection}
+                  </List>
+                </Drawer>
+
+                <Box
+                  component="main"
                   sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "flex-end",
-                    px: [1],
+                    backgroundColor: DARK_TAN_COLOR,
+                    flexGrow: 1,
+                    height: "100vh",
+                    overflow: "auto",
                   }}
                 >
-                  <IconButton onClick={toggleDrawer}>
-                    <ChevronLeftIcon />
-                  </IconButton>
-                </Toolbar>
-                <Divider />
-                <List component="nav">
-                  {DrawerToolsSection}
-                  <Divider sx={{ my: 1 }} />
-                  {DrawerDataTablesSection}
-                  <Divider sx={{ my: 1 }} />
-                  {DrawerLinksSection}
-                </List>
-              </Drawer>
-
-              <Box
-                component="main"
-                sx={{
-                  backgroundColor: DARK_TAN_COLOR,
-                  flexGrow: 1,
-                  height: "100vh",
-                  overflow: "auto",
-                }}
-              >
-                <Toolbar />
-                <Container maxWidth={false} sx={{ mt: 2, mb: 2, backgroundColor: DARK_TAN_COLOR }}>
-                  <Routes>
-                    <Route path="/" element={<CivComparePage />} />
-                    <Route path="/civdata" element={<CivDataPage />} />
-                    <Route path="/unitdata" element={<UnitDataPage />} />
-                    <Route path="/techdata" element={<TechDataPage />} />
-                    <Route path="/buildingdata" element={<BuildingDataPage />} />
-                  </Routes>
-                  <Copyright sx={{ pt: 4 }} />
-                </Container>
+                  <Toolbar />
+                  <Container maxWidth={false} sx={{ mt: 2, mb: 2, backgroundColor: DARK_TAN_COLOR }}>
+                    <Routes>
+                      <Route path="/" element={<CivComparePage />} />
+                      <Route path="/civdata" element={<CivDataPage />} />
+                      <Route path="/unitdata" element={<UnitDataPage />} />
+                      <Route path="/techdata" element={<TechDataPage />} />
+                      <Route path="/buildingdata" element={<BuildingDataPage />} />
+                    </Routes>
+                    <Copyright sx={{ pt: 4 }} />
+                  </Container>
+                </Box>
               </Box>
-            </Box>
-          </UnitContext.Provider>
-        </CivContext.Provider>
-      </TechContext.Provider>
-    </BuildingContext.Provider>
+            </UnitContext.Provider>
+          </CivContext.Provider>
+        </TechContext.Provider>
+      </BuildingContext.Provider>
+    </SettingsContext.Provider>
   );
 }
 

--- a/src/contexts/SettingsContext.ts
+++ b/src/contexts/SettingsContext.ts
@@ -1,0 +1,6 @@
+import React from "react";
+import { Settings } from "../types";
+
+const SettingsContext = React.createContext<Settings | null>(null);
+
+export { SettingsContext };

--- a/src/contexts/SettingsContext.ts
+++ b/src/contexts/SettingsContext.ts
@@ -1,6 +1,10 @@
 import React from "react";
-import { Settings } from "../types";
+import type { Settings } from "../types";
 
-const SettingsContext = React.createContext<Settings | null>(null);
+export const DEFAULT_SETTINGS: Settings = {
+  showEliteUnits: false,
+};
+
+const SettingsContext = React.createContext<Settings>(DEFAULT_SETTINGS);
 
 export { SettingsContext };

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -2,3 +2,4 @@ export * from "./BuildingContext";
 export * from "./CivContext";
 export * from "./TechContext";
 export * from "./UnitContext";
+export * from "./SettingsContext";

--- a/src/data/civs.json
+++ b/src/data/civs.json
@@ -28,7 +28,7 @@
     "id": 3,
     "expansion": "The African Kingdoms",
     "army_type": "Cavalry and Naval",
-    "unique_unit": "Camel Archer;Elite Camel Archer",
+    "unique_unit": "Camel Archer;Elite Camel Archer;Genitour;Elite Genitour",
     "unique_tech": "Kasbah;Maghrabi Camels",
     "team_bonus": "Genitours are available at the Archery Range.",
     "civilization_bonus": "Villagers move +10% faster.;Stable units are 15%/20% cheaper in the Castle/Imperial Age.;Ships move +10% faster.",

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -1,0 +1,3 @@
+export type Settings = {
+  showEliteUnits: boolean;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,3 +3,4 @@ export * from "./Civilization";
 export * from "./Technology";
 export * from "./Building";
 export * from "./Cost";
+export * from "./Settings";


### PR DESCRIPTION
- Added new `SettingsContext` to handle app settings
- `showEliteUnits` is a new setting with a checkbox that hides or shows elite units in the civ compare window (value is false by default)
- Added Genitours as unique unit for Berbers